### PR TITLE
Allow section signs

### DIFF
--- a/src/main/java/me/youhavetrouble/justchat/JustChatListener.java
+++ b/src/main/java/me/youhavetrouble/justchat/JustChatListener.java
@@ -9,6 +9,7 @@ import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.kyori.adventure.text.minimessage.tag.standard.StandardTags;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -46,10 +47,13 @@ public class JustChatListener implements Listener {
         if (event.player() == null) return;
 
         String format = ConfigHandling.Message.CHAT_FORMAT.getMessage();
-
+        Component formatComponent;
         format = PlaceholderAPI.setPlaceholders(event.player(), format);
-        Component formatComponent = JustChat.getMiniMessage().deserialize(format);
-
+        if(format.contains("§")){
+            formatComponent = LegacyComponentSerializer.legacySection().deserialize(format);
+        } else {
+            formatComponent = JustChat.getMiniMessage().deserialize(format);
+        }
         Component message = parseMessageContent(event.player(), plainTextComponentSerializer.serialize(event.originalMessage()));
 
         event.result(formatComponent.replaceText(TextReplacementConfig.builder().match("%message%").replacement(message).build()));


### PR DESCRIPTION
Fixes https://github.com/YouHaveTrouble/JustChat/issues/1
Allows usage of placeholders that use section signs 
Note, if using these placeholders, and trying to use colors in the config, you must also use section signs. 

Using this format while using placeholders that have section signs will result in something like this
`"%luckperms_prefix%<yellow>%player_displayname%» %message%"`
![image](https://user-images.githubusercontent.com/45906780/193965587-27ad3735-536a-4325-ad8c-0dbd9e218299.png)

This will work as intended
`"%luckperms_prefix%§e%player_displayname%§r» %message%"`
![image](https://user-images.githubusercontent.com/45906780/193965637-b76daa1e-84bf-445d-83b0-e113c70d789c.png)
![image](https://user-images.githubusercontent.com/45906780/193965663-3b3569e1-f385-4483-bd02-6c098f1c1f48.png)

![image](https://user-images.githubusercontent.com/45906780/193965883-3bde9446-e4e4-4fd6-a6fb-3fd9b6e091d4.png)
![image](https://user-images.githubusercontent.com/45906780/193965933-04500e7d-ed60-4866-96cb-f1aa7e45a4fc.png)
